### PR TITLE
Pipe stdin async

### DIFF
--- a/Classes/Util/PBEasyPipe.m
+++ b/Classes/Util/PBEasyPipe.m
@@ -86,15 +86,21 @@
 	}
 
 	NSFileHandle* handle = [[task standardOutput] fileHandleForReading];
+	NSFileHandle *inHandle = nil;
 
 	if (input) {
 		[task setStandardInput:[NSPipe pipe]];
-		NSFileHandle *inHandle = [[task standardInput] fileHandleForWriting];
-		[inHandle writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
-		[inHandle closeFile];
+		inHandle = [[task standardInput] fileHandleForWriting];
 	}
 	
 	[task launch];
+
+	if (input && inHandle) {
+		dispatch_async(dispatch_get_global_queue(0, 0), ^{
+			[inHandle writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
+			[inHandle closeFile];
+		});
+	}
 	
 	NSData* data = [handle readDataToEndOfFile];
 	NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];

--- a/Classes/Util/PBEasyPipe.m
+++ b/Classes/Util/PBEasyPipe.m
@@ -96,6 +96,9 @@
 	[task launch];
 
 	if (input && inHandle) {
+		// A large write could wait for stdout buffer to be flushed by the task,
+		// which may not happen until the task is run. The task may similarly wait
+		// for its stdout to be read before reading its stdin, causing a deadlock.
 		dispatch_async(dispatch_get_global_queue(0, 0), ^{
 			[inHandle writeData:[input dataUsingEncoding:NSUTF8StringEncoding]];
 			[inHandle closeFile];


### PR DESCRIPTION
I've found that in El Capitan staging of lines often locks GitX up. 

I think it's due to stdin buffer filling up and `writeData:` waiting for the task to read it, but the task isn't launched yet.

Similarly the executable could potentially wait for stdout to be read by the parent before reading stdin, which is why write is async to run in parallel with the read.