### PR TITLE
Fix Open File and Show in Finder context menu entries

### DIFF
--- a/Classes/Controllers/PBGitHistoryController.m
+++ b/Classes/Controllers/PBGitHistoryController.m
@@ -32,6 +32,7 @@
 #import "PBQLTextView.h"
 #import "GLFileView.h"
 #import "GitXCommitCopier.h"
+#import "PBOpenFiles.h"
 
 
 #define kHistorySelectedDetailIndexKey @"PBHistorySelectedDetailIndex"
@@ -590,6 +591,16 @@
 	for (NSString *filePath in [sender representedObject])
 		[files addObject:[filePath stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
 	[repository checkoutFiles:files fromRefish:self.selectedCommits.firstObject];
+}
+
+- (void) openFilesAction:(id) sender
+{
+	[PBOpenFiles openFilesAction:sender with:repository.workingDirectoryURL];
+}
+
+- (void) showInFinderAction:(id) sender
+{
+	[PBOpenFiles showInFinderAction:sender with:repository.workingDirectoryURL];
 }
 
 - (void) diffFilesAction:(id)sender

--- a/Classes/Controllers/PBGitIndexController.m
+++ b/Classes/Controllers/PBGitIndexController.m
@@ -10,6 +10,7 @@
 #import "PBChangedFile.h"
 #import "PBGitRepository.h"
 #import "PBGitIndex.h"
+#import "PBOpenFiles.h"
 
 #define FileChangesTableViewType @"GitFileChangedType"
 
@@ -113,7 +114,7 @@
 
 	NSString *title = [selectedFiles count] == 1 ? @"Open file" : @"Open files";
 	NSMenuItem *openItem = [[NSMenuItem alloc] initWithTitle:title action:@selector(openFilesAction:) keyEquivalent:@""];
-	[openItem setTarget:commitController.repository];
+	[openItem setTarget:self];
 	[menu addItem:openItem];
 
 	// Attempt to ignore
@@ -126,7 +127,7 @@
 
 	if ([selectedFiles count] == 1) {
 		NSMenuItem *showInFinderItem = [[NSMenuItem alloc] initWithTitle:@"Show in Finder" action:@selector(showInFinderAction:) keyEquivalent:@""];
-		[showInFinderItem setTarget:commitController.repository];
+		[showInFinderItem setTarget:self];
 		[menu addItem:showInFinderItem];
     }
 
@@ -217,6 +218,11 @@
 	[commitController.index unstageFiles:[sender representedObject]];
 }
 
+- (void) openFilesAction:(id) sender
+{
+	[PBOpenFiles openFilesAction:sender with:commitController.repository.workingDirectoryURL];
+}
+
 - (void) ignoreFilesAction:(id) sender
 {
 	NSArray *selectedFiles = [sender representedObject];
@@ -225,6 +231,11 @@
 
 	[self ignoreFiles:selectedFiles];
 	[commitController.index refresh];
+}
+
+- (void) showInFinderAction:(id) sender
+{
+	[PBOpenFiles showInFinderAction:sender with:commitController.repository.workingDirectoryURL];
 }
 
 - (void)discardFilesAction:(id) sender

--- a/Classes/Controllers/PBGitRepositoryDocument.h
+++ b/Classes/Controllers/PBGitRepositoryDocument.h
@@ -22,10 +22,6 @@ extern NSString *PBGitRepositoryDocumentType;
 // Scripting Bridge
 - (void)findInModeScriptCommand:(NSScriptCommand *)command;
 
-// Responder
-- (IBAction)showInFinderAction:(id)sender;
-- (IBAction)openFilesAction:(id)sender;
-
 - (IBAction)showCommitView:(id)sender;
 - (IBAction)showHistoryView:(id)sender;
 

--- a/Classes/Controllers/PBGitRepositoryDocument.m
+++ b/Classes/Controllers/PBGitRepositoryDocument.m
@@ -134,52 +134,6 @@ NSString *PBGitRepositoryDocumentType = @"Git Repository";
 }
 
 #pragma mark -
-#pragma mark NSResponder methods
-
-- (NSArray *)selectedURLsFromSender:(id)sender {
-	NSArray *selectedFiles = [sender representedObject];
-	if ([selectedFiles count] == 0)
-		return nil;
-
-	NSURL *workingDirectoryURL = self.repository.workingDirectoryURL;
-	NSMutableArray *URLs = [NSMutableArray array];
-    for (id file in selectedFiles) {
-        NSString *path = file;
-        // Those can be PBChangedFiles sent by PBGitIndexController. Get their path.
-        if ([file respondsToSelector:@selector(path)]) {
-            path = [file path];
-        }
-
-        if (![path isKindOfClass:[NSString class]])
-            continue;
-        [URLs addObject:[workingDirectoryURL URLByAppendingPathComponent:path]];
-    }
-
-    return URLs;
-}
-
-- (IBAction)showInFinderAction:(id)sender {
-    NSArray *URLs = [self selectedURLsFromSender:sender];
-    if ([URLs count] == 0)
-        return;
-
-    [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:URLs];
-}
-
-- (IBAction)openFilesAction:(id)sender {
-    NSArray *URLs = [self selectedURLsFromSender:sender];
-
-    if ([URLs count] == 0)
-        return;
-
-    [[NSWorkspace sharedWorkspace] openURLs:URLs
-                    withAppBundleIdentifier:nil
-                                    options:0
-             additionalEventParamDescriptor:nil
-                          launchIdentifiers:NULL];
-}
-
-#pragma mark -
 #pragma mark AppleScript support
 
 - (void)handleRevListArguments:(NSArray *)arguments

--- a/Classes/Util/PBOpenFiles.h
+++ b/Classes/Util/PBOpenFiles.h
@@ -1,0 +1,16 @@
+//
+//  PBOpenFiles.h
+//  GitX
+//
+//  Created by Tommy Sparber on 02/08/16.
+//  Based on code by Etienne
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PBOpenFiles : NSObject
+
++ (void)showInFinderAction:(id)sender with:(NSURL *)workingDirectoryURL;
++ (void)openFilesAction:(id)sender with:(NSURL *)workingDirectoryURL;
+
+@end

--- a/Classes/Util/PBOpenFiles.m
+++ b/Classes/Util/PBOpenFiles.m
@@ -1,0 +1,55 @@
+//
+//  PBOpenFiles.m
+//  GitX
+//
+//  Created by Tommy Sparber on 02/08/16.
+//  Based on code by Etienne
+//
+
+#import "PBOpenFiles.h"
+
+@implementation PBOpenFiles
+
++ (NSArray *)selectedURLsFromSender:(id)sender with:(NSURL *)workingDirectoryURL {
+	NSArray *selectedFiles = [sender representedObject];
+	if ([selectedFiles count] == 0)
+		return nil;
+
+	NSMutableArray *URLs = [NSMutableArray array];
+	for (id file in selectedFiles) {
+		NSString *path = file;
+		// Those can be PBChangedFiles sent by PBGitIndexController. Get their path.
+		if ([file respondsToSelector:@selector(path)]) {
+			path = [file path];
+		}
+
+		if (![path isKindOfClass:[NSString class]])
+			continue;
+		[URLs addObject:[workingDirectoryURL URLByAppendingPathComponent:path]];
+	}
+
+	return URLs;
+}
+
++ (void)showInFinderAction:(id)sender with:(NSURL *)workingDirectoryURL {
+	NSArray *URLs = [self selectedURLsFromSender:sender with:workingDirectoryURL];
+	if ([URLs count] == 0)
+		return;
+
+	[[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:URLs];
+}
+
++ (void)openFilesAction:(id)sender with:(NSURL *)workingDirectoryURL {
+	NSArray *URLs = [self selectedURLsFromSender:sender with:workingDirectoryURL];
+
+	if ([URLs count] == 0)
+		return;
+
+	[[NSWorkspace sharedWorkspace] openURLs:URLs
+					withAppBundleIdentifier:nil
+									options:0
+			 additionalEventParamDescriptor:nil
+						  launchIdentifiers:NULL];
+}
+
+@end

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		4D3FB3E7198AEAAF000B4A58 /* PBGitRepositoryDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D3FB3E6198AEAAF000B4A58 /* PBGitRepositoryDocument.m */; };
 		551BF176112F3F4B00265053 /* gitx_askpasswd in Resources */ = {isa = PBXBuildFile; fileRef = 551BF111112F371800265053 /* gitx_askpasswd */; };
 		643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */; };
+		658CD8671D50F93500F5F019 /* PBOpenFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 658CD8661D50F93500F5F019 /* PBOpenFiles.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		911112370E5A097800BF76B4 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 911112360E5A097800BF76B4 /* Security.framework */; };
@@ -580,6 +581,8 @@
 		551BF111112F371800265053 /* gitx_askpasswd */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gitx_askpasswd; sourceTree = BUILT_PRODUCTS_DIR; };
 		643952751603EF9B00BB7AFF /* PBGitSVSubmoduleItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitSVSubmoduleItem.h; sourceTree = "<group>"; };
 		643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitSVSubmoduleItem.m; sourceTree = "<group>"; };
+		658CD8651D50F93500F5F019 /* PBOpenFiles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PBOpenFiles.h; path = Classes/Util/PBOpenFiles.h; sourceTree = SOURCE_ROOT; };
+		658CD8661D50F93500F5F019 /* PBOpenFiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PBOpenFiles.m; path = Classes/Util/PBOpenFiles.m; sourceTree = SOURCE_ROOT; };
 		6C2581091C2720E60080A89A /* GitXCommitCopier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitXCommitCopier.h; sourceTree = "<group>"; };
 		6C25810A1C2720E60080A89A /* GitXCommitCopier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitXCommitCopier.m; sourceTree = "<group>"; };
 		77C82804067257F0000B614F /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
@@ -986,6 +989,8 @@
 				4A5D76B014A9A9CC00DF6C68 /* PBEasyFS.m */,
 				4A5D76B114A9A9CC00DF6C68 /* PBEasyPipe.h */,
 				4A5D76B214A9A9CC00DF6C68 /* PBEasyPipe.m */,
+				658CD8651D50F93500F5F019 /* PBOpenFiles.h */,
+				658CD8661D50F93500F5F019 /* PBOpenFiles.m */,
 				4AB71FF614B7EDD400F1DFFC /* RJModalRepoSheet.h */,
 				4AB71FF714B7EDD400F1DFFC /* RJModalRepoSheet.m */,
 				6C2581091C2720E60080A89A /* GitXCommitCopier.h */,
@@ -1427,6 +1432,7 @@
 				4A5D770A14A9A9CC00DF6C68 /* PBGitSVStageItem.m in Sources */,
 				4A5D770B14A9A9CC00DF6C68 /* PBGitSVTagItem.m in Sources */,
 				4A5D770C14A9A9CC00DF6C68 /* PBGitTree.m in Sources */,
+				658CD8671D50F93500F5F019 /* PBOpenFiles.m in Sources */,
 				4A5D770D14A9A9CC00DF6C68 /* PBGitXErrors.m in Sources */,
 				4A5D770E14A9A9CC00DF6C68 /* PBGitXProtocol.m in Sources */,
 				4A5D771114A9A9CC00DF6C68 /* GitXRelativeDateFormatter.m in Sources */,


### PR DESCRIPTION
The commit 9335f0e82ef90238eb99b94a8167bce8104e6bad breaks the context menu entries (“Show in Finder” and “Open Files”) in the commit controller, as the code is moved from PBGitRepository to PBGitRepositoryDocument.

The fix creates a new class PBOpenFiles that is used in PBGitHistoryController and PBGitIndexController. Any comment on a better location of these two functions?

@ssp Do you think it would be better to create the PR at tiennou's fork?