### PR TITLE
Clickable and fixed-width diff collapse arrows

### DIFF
--- a/html/css/GitX.css
+++ b/html/css/GitX.css
@@ -13,12 +13,18 @@ table {
 	font-size: 12px;
 }
 
-.expanded:before {
-  content: "\25be\0020";
+.fileHeader a:before {
+    margin-left: 0.3em;
+    width: 1em;
+    display: inline-block;
 }
 
-.collapsed:before {
-  content: "\25b8\0020";
+.expanded a:before {
+    content: "\25be\0020";
+}
+
+.collapsed a:before {
+    content: "\25b8\0020";
 }
 
 .SHA {


### PR DESCRIPTION
Moves the arrow :before content into the <a> so they’re clickable, and sets a fixed width so the filename doesn’t wiggle when toggling between the right and down arrows.

Before:
![before](https://cloud.githubusercontent.com/assets/34699/19623459/f2733ae4-9886-11e6-9eeb-2fbf206e6918.gif)
After:
![after](https://cloud.githubusercontent.com/assets/34699/19623467/201e2580-9887-11e6-9b23-5a55447880c5.gif)

The flickering is a gif artifact.