### PR TITLE
Faster diff collapse and expansion

### DIFF
--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -13,9 +13,9 @@ var toggleDiff = function(id)
     var collapsed = (content.style.display == 'none');
 	  if (collapsed) {
 		  content.style.display = 'box';
-		  jQuery(content).fadeTo('slow', 1).slideDown();
+		  jQuery(content).slideDown(100);
 	  } else {
-		  jQuery(content).fadeTo('fast', 0).slideUp('fast', function () {content.style.display = 'none'});
+          jQuery(content).slideUp(100, function () {content.style.display = 'none'});
 	  }
 	
     var title = document.getElementById('title_' + id);


### PR DESCRIPTION
Removes the fade, and halves the shorts animation time.

Before:
![before](https://cloud.githubusercontent.com/assets/34699/19623459/f2733ae4-9886-11e6-9eeb-2fbf206e6918.gif)
After:
![after](https://cloud.githubusercontent.com/assets/34699/19623471/88fe0e8a-9887-11e6-8bf2-80d3308a710b.gif)
