### PR TITLE
Fix extra trailing blank lines on commit messages

### DIFF
--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -26,7 +26,7 @@ var Commit = function(obj) {
 		var afterHeader = this.summaryRaw.substring(messageStart);
 		var numstatStart = afterHeader.indexOf("\n\n") + 2;
 		if (numstatStart > 1) {
-			this.message = afterHeader.substring(0, numstatStart).replace(/^    /gm, "").escapeHTML();;
+			this.message = afterHeader.substring(0, numstatStart - 2).replace(/^    /gm, "").escapeHTML();;
 			var afterMessage = afterHeader.substring(numstatStart);
 			var filechangeStart = afterMessage.indexOf("\n ") + 1;
 			if (filechangeStart > 1) {


### PR DESCRIPTION
The extra newlines are from the \n\n between the message and the file list:

```
committer NanoTech <nanotech@nanotechcorp.net> 1477180053 -0600

    Fix extra trailing blank lines on commit messages

1	1	html/views/history/history.js
```

Before:
![before](https://cloud.githubusercontent.com/assets/34699/19623479/2a9fe772-9888-11e6-9c7e-8610949c1ff6.png)
After:
![after](https://cloud.githubusercontent.com/assets/34699/19623481/316a2d4c-9888-11e6-9c43-936a4d3de8b3.png)
