### PR TITLE
Display missing newlines clearly

### DIFF
--- a/html/css/diff.css
+++ b/html/css/diff.css
@@ -51,6 +51,10 @@
     display:none;
 }
 
+.diff .file .diffcontent .lines .nonewline:after {
+	content: "  \20e0\23ce";
+	font-family: -apple-system, "Helvetica Neue", sans-serif;
+}
 .diff .file .diffcontent .lines .whitespace {
 	background-color: rgba(255,0,0,0.5);
 }

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -213,15 +213,24 @@ var highlightDiff = function(diff, element, callbacks) {
 				continue;
 		}
 
+		var isMissingEOFNewline =
+		    lineno + 1 < lines.length &&
+		    lines[lineno + 1] == "\\ No newline at end of file";
+		var missingEOFNewlineClass = isMissingEOFNewline ? " nonewline" : "";
+		var wrapLine = function(cls) {
+			return "<div " + sindex + "class='" + cls + missingEOFNewlineClass + "'>"
+			    + l + "</div>";
+		};
+
 		sindex = "index=" + lindex.toString() + " ";
 		if (firstChar == "+") {
 			line1 += "\n";
 			line2 += ++hunk_start_line_2 + "\n";
-			diffContent += "<div " + sindex + "class='addline'>" + l + "</div>";
+			diffContent += wrapLine("addline");
 		} else if (firstChar == "-") {
 			line1 += ++hunk_start_line_1 + "\n";
 			line2 += "\n";
-			diffContent += "<div " + sindex + "class='delline'>" + l + "</div>";
+			diffContent += wrapLine("delline");
 		} else if (firstChar == "@") {
 			if (header) {
 				header = false;
@@ -234,13 +243,13 @@ var highlightDiff = function(diff, element, callbacks) {
 			}
 			line1 += "...\n";
 			line2 += "...\n";
-			diffContent += "<div " + sindex + "class='hunkheader'>" + l + "</div>";
+			diffContent += wrapLine("hunkheader");
 		} else if (firstChar == " ") {
 			line1 += ++hunk_start_line_1 + "\n";
 			line2 += ++hunk_start_line_2 + "\n";
-			diffContent += "<div " + sindex + "class='noopline'>" + l + "</div>";
+			diffContent += wrapLine("noopline");
 		} else if (firstChar == "\\") {
-			diffContent += "<div " + sindex + "class='markerline'>" + l + "</div>";
+			diffContent += wrapLine("markerline");
 		}
 		lindex++;
 	}

--- a/html/lib/diffHighlighter.js
+++ b/html/lib/diffHighlighter.js
@@ -240,8 +240,6 @@ var highlightDiff = function(diff, element, callbacks) {
 			line2 += ++hunk_start_line_2 + "\n";
 			diffContent += "<div " + sindex + "class='noopline'>" + l + "</div>";
 		} else if (firstChar == "\\") {
-			line1 += ++hunk_start_line_1 + "\n";
-			line2 += ++hunk_start_line_2 + "\n";
 			diffContent += "<div " + sindex + "class='markerline'>" + l + "</div>";
 		}
 		lindex++;


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/34699/19623499/e82ab34e-9888-11e6-895c-4bb09e99c05b.png)
After:
![after](https://cloud.githubusercontent.com/assets/34699/19623500/eadfc12e-9888-11e6-8307-e70a19fb1796.png)