### PR TITLE
Load historical commit details with ObjectiveGit

### DIFF
--- a/Classes/git/PBGitCommit.h
+++ b/Classes/git/PBGitCommit.h
@@ -21,12 +21,18 @@ extern NSString * const kGitXCommitType;
 
 @property (nonatomic, weak, readonly) PBGitRepository* repository;
 
+@property (nonatomic, strong, readonly) GTCommit *gtCommit;
 @property (nonatomic, strong, readonly) GTOID *OID;
 
 @property (nonatomic, strong, readonly) NSDate *date;
 @property (nonatomic, strong, readonly) NSString *subject;
+@property (nonatomic, strong, readonly) NSString *message;
 @property (nonatomic, strong, readonly) NSString *author;
+@property (nonatomic, strong, readonly) NSString *authorEmail;
+@property (nonatomic, strong, readonly) NSString *authorDate;
 @property (nonatomic, strong, readonly) NSString *committer;
+@property (nonatomic, strong, readonly) NSString *committerEmail;
+@property (nonatomic, strong, readonly) NSString *committerDate;
 @property (nonatomic, strong, readonly) NSString *details;
 @property (nonatomic, strong, readonly) NSString *patch;
 @property (nonatomic, strong, readonly) NSString *SHA;

--- a/Classes/git/PBGitCommit.m
+++ b/Classes/git/PBGitCommit.m
@@ -28,6 +28,18 @@ NSString * const kGitXCommitType = @"commit";
 
 @implementation PBGitCommit
 
++ (NSDateFormatter *)longDateFormatter {
+	static NSDateFormatter *formatter = nil;
+	static dispatch_once_t token;
+	dispatch_once(&token, ^{
+		NSDateFormatter *f = [[NSDateFormatter alloc] init];
+		f.dateStyle = NSDateFormatterLongStyle;
+		f.timeStyle = NSDateFormatterLongStyle;
+		formatter = f;
+	});
+	return formatter;
+}
+
 - (NSDate *) date
 {
 	return self.gtCommit.commitDate;
@@ -76,16 +88,41 @@ NSString * const kGitXCommitType = @"commit";
 	return self.gtCommit.messageSummary;
 }
 
+- (NSString *)message
+{
+	return self.gtCommit.message;
+}
+
 - (NSString *)author
 {
 	NSString *result = self.gtCommit.author.name;
 	return result;
 }
 
+- (NSString *)authorEmail
+{
+	return self.gtCommit.author.email;
+}
+
+- (NSString *)authorDate
+{
+	return [[[self class] longDateFormatter] stringFromDate:self.gtCommit.author.time];
+}
+
 - (NSString *)committer
 {
 	GTSignature *sig = self.gtCommit.committer;
 	return sig.name;
+}
+
+- (NSString *)committerEmail
+{
+	return self.gtCommit.committer.email;
+}
+
+- (NSString *)committerDate
+{
+	return [[[self class] longDateFormatter] stringFromDate:self.gtCommit.committer.time];
 }
 
 - (NSString *)SVNRevision

--- a/html/views/history/history.js
+++ b/html/views/history/history.js
@@ -19,23 +19,6 @@ var Commit = function(obj) {
 	this.message = obj.message();
 	this.notificationID = null;
 
-	this.parseSummary = function(summary) {
-		this.filesInfo = summary.filesInfo;
-	}
-
-	// This can be called later with the output of
-	// 'git show' to get the full diff
-	this.parseFullDiff = function(fullDiff) {
-		this.fullDiffRaw = fullDiff;
-
-		var diffStart = this.fullDiffRaw.indexOf("\ndiff ");
-		if (diffStart > 0) {
-			this.diff = this.fullDiffRaw.substring(diffStart);
-		} else {
-			this.diff = "";
-		}
-	}
-
 	this.reloadRefs = function() {
 		this.refs = this.object.refs();
 	}
@@ -310,10 +293,12 @@ var enableFeatures = function()
 	enableFeature("gravatar", $("committer_gravatar").parentNode)
 }
 
-var loadCommitSummary = function(summaryJSON)
+var loadCommitDiff = function(jsonData)
 {
-	commit.parseSummary(JSON.parse(summaryJSON));
-	
+	var diffData = JSON.parse(jsonData)
+	commit.filesInfo = diffData.filesInfo;
+	commit.diff = diffData.fullDiff;
+
 	if (commit.notificationID)
 		clearTimeout(commit.notificationID)
 		else
@@ -411,11 +396,6 @@ var loadCommitSummary = function(summaryJSON)
 		}
 		$("files").style.display = "";
 	}
-}
-
-var loadCommitFullDiff = function(data)
-{
-	commit.parseFullDiff(data);
 
 	if (commit.diff.length < 200000)
 		showDiff();


### PR DESCRIPTION
This also merges the loadCommitSummary and loadCommitFullDiff steps, as the full diff needs to be calculated to calculate the summarized diff number anyways.

A new `GTRepository` is opened for each task on the background queue. It [might be safe](https://github.com/libgit2/libgit2/blob/67dd314086fd743f2fc5032e9c7ff901cb5e8bab/THREADING.md) to just share it between threads, since it's read-only (aside from caching), but I'm not sure.

I also have [another patch](https://github.com/nanotech/gitx/commit/9b960d99b6a1455ac027a62f99a82255be254a63) to display changes in sizes for binary files, but it depends on this PR.
